### PR TITLE
deps: Bump hugo-mod-mermaidjs from 0.4.0 to 0.5.0

### DIFF
--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,8 +1,8 @@
 github.com/hakimel/reveal.js v0.0.0-20201012095104-0582f57517c9/go.mod h1:vIoaZ8tJbfDF30DhKf6Dia5ykePO0tETa9Posw8UrOE=
 github.com/jgthms/bulma v0.0.0-20200928223852-9928dba42d75/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=
 github.com/mathjax/MathJax v0.0.0-20200912194947-c8292351190c/go.mod h1:bgp6XP7Dtl25/x6vVIPVe2mkOCrg8wMk/A9gl0FzJLA=
-github.com/mermaid-js/mermaid v8.8.4+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
+github.com/mermaid-js/mermaid v8.8.5-0.20210121183421-3c5da00230a5+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
 github.com/peaceiris/hugo-mod-bulma v0.1.2/go.mod h1:Oldyip8pv+p8c94jOprxEJ+0+IzDyYi3t/kpZ3txDnM=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1/go.mod h1:NTn10syjBq7EVnZACmoOlZlg+D3MXLDo9jOLdq5Bm5g=
-github.com/peaceiris/hugo-mod-mermaidjs v0.4.0/go.mod h1:La8QvJ2PL9gOshB8eGNDAgSEf1+V9FDuybioM4JTk64=
+github.com/peaceiris/hugo-mod-mermaidjs v0.5.0/go.mod h1:OmVUZM92FWgDVTt4uZ2qawHGNRRsSMU6uexWMDKjp4o=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0/go.mod h1:j0j0jS675O/rIk2kBdyTbkQebg9wYSriFfDZG+SkHYs=

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/peaceiris/hugo-mod-bulma v0.1.2 // indirect
 	github.com/peaceiris/hugo-mod-mathjax v0.1.1 // indirect
-	github.com/peaceiris/hugo-mod-mermaidjs v0.4.0 // indirect
+	github.com/peaceiris/hugo-mod-mermaidjs v0.5.0 // indirect
 	github.com/peaceiris/hugo-mod-revealjs v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,12 @@
 github.com/hakimel/reveal.js v0.0.0-20201012095104-0582f57517c9/go.mod h1:vIoaZ8tJbfDF30DhKf6Dia5ykePO0tETa9Posw8UrOE=
 github.com/jgthms/bulma v0.0.0-20200928223852-9928dba42d75/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=
 github.com/mathjax/MathJax v0.0.0-20200912194947-c8292351190c/go.mod h1:bgp6XP7Dtl25/x6vVIPVe2mkOCrg8wMk/A9gl0FzJLA=
-github.com/mermaid-js/mermaid v8.8.4+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
+github.com/mermaid-js/mermaid v8.8.5-0.20210121183421-3c5da00230a5+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
 github.com/peaceiris/hugo-mod-bulma v0.1.2 h1:NeOSqatA04bkJxewIjFdEoQlhfBBDtoSl0fh0NS4k+g=
 github.com/peaceiris/hugo-mod-bulma v0.1.2/go.mod h1:Oldyip8pv+p8c94jOprxEJ+0+IzDyYi3t/kpZ3txDnM=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1 h1:HYfqwE/5dOChaRWBiy8KkNTC6d/RRVNuroE6ld5vGws=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1/go.mod h1:NTn10syjBq7EVnZACmoOlZlg+D3MXLDo9jOLdq5Bm5g=
-github.com/peaceiris/hugo-mod-mermaidjs v0.4.0 h1:lIASwQQQG950yAdAGidJruqpDwYHJwumGwH1HUV+HJM=
-github.com/peaceiris/hugo-mod-mermaidjs v0.4.0/go.mod h1:La8QvJ2PL9gOshB8eGNDAgSEf1+V9FDuybioM4JTk64=
+github.com/peaceiris/hugo-mod-mermaidjs v0.5.0 h1:ucDrPJVZ+5nwx3YpYduPL3HB2phMkuMrW5t1KOjQ+XU=
+github.com/peaceiris/hugo-mod-mermaidjs v0.5.0/go.mod h1:OmVUZM92FWgDVTt4uZ2qawHGNRRsSMU6uexWMDKjp4o=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0 h1:uIdNBMhSiRujqaf7WHqcXb2qsmkodFVL1o2Vzm/aS6Q=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0/go.mod h1:j0j0jS675O/rIk2kBdyTbkQebg9wYSriFfDZG+SkHYs=


### PR DESCRIPTION
- [Release 8.9.0 · mermaid-js/mermaid](https://github.com/mermaid-js/mermaid/releases/tag/8.9.0)
- [Release hugo-mod-mermaidjs v0.5.0 · peaceiris/hugo-mod-mermaidjs](https://github.com/peaceiris/hugo-mod-mermaidjs/releases/tag/v0.5.0)

```
hugo mod get -u github.com/peaceiris/hugo-mod-mermaidjs && hugo mod tidy && hugo mod verify
cd exampleSite
hugo mod tidy && hugo mod verify
```