### PR TITLE
deps: Bump hugo-mod-mermaidjs from 0.5.0 to 0.6.0

### DIFF
--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,8 +1,8 @@
 github.com/hakimel/reveal.js v0.0.0-20201012095104-0582f57517c9/go.mod h1:vIoaZ8tJbfDF30DhKf6Dia5ykePO0tETa9Posw8UrOE=
 github.com/jgthms/bulma v0.0.0-20210126190202-c5edaea84f28/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=
 github.com/mathjax/MathJax v0.0.0-20200912194947-c8292351190c/go.mod h1:bgp6XP7Dtl25/x6vVIPVe2mkOCrg8wMk/A9gl0FzJLA=
-github.com/mermaid-js/mermaid v8.8.5-0.20210121183421-3c5da00230a5+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
+github.com/mermaid-js/mermaid v8.8.5-0.20210218204101-be95b93a2d91+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
 github.com/peaceiris/hugo-mod-bulma v0.2.0/go.mod h1:sjw6OFwTiXqh6S26Wk6GYjlSlwgKjYZ06+Bj29FLIqQ=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1/go.mod h1:NTn10syjBq7EVnZACmoOlZlg+D3MXLDo9jOLdq5Bm5g=
-github.com/peaceiris/hugo-mod-mermaidjs v0.5.0/go.mod h1:OmVUZM92FWgDVTt4uZ2qawHGNRRsSMU6uexWMDKjp4o=
+github.com/peaceiris/hugo-mod-mermaidjs v0.6.0/go.mod h1:Evqp1vX8GAhk5UDjAe1/VXmXn3ej34HdKFabu+rMVk4=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0/go.mod h1:j0j0jS675O/rIk2kBdyTbkQebg9wYSriFfDZG+SkHYs=

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/peaceiris/hugo-mod-bulma v0.2.0 // indirect
 	github.com/peaceiris/hugo-mod-mathjax v0.1.1 // indirect
-	github.com/peaceiris/hugo-mod-mermaidjs v0.5.0 // indirect
+	github.com/peaceiris/hugo-mod-mermaidjs v0.6.0 // indirect
 	github.com/peaceiris/hugo-mod-revealjs v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,12 @@
 github.com/hakimel/reveal.js v0.0.0-20201012095104-0582f57517c9/go.mod h1:vIoaZ8tJbfDF30DhKf6Dia5ykePO0tETa9Posw8UrOE=
 github.com/jgthms/bulma v0.0.0-20210126190202-c5edaea84f28/go.mod h1:89FLBKXYFKfOKAoDeUT26V0pHGwzr205cMXAEqtAVOI=
 github.com/mathjax/MathJax v0.0.0-20200912194947-c8292351190c/go.mod h1:bgp6XP7Dtl25/x6vVIPVe2mkOCrg8wMk/A9gl0FzJLA=
-github.com/mermaid-js/mermaid v8.8.5-0.20210121183421-3c5da00230a5+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
+github.com/mermaid-js/mermaid v8.8.5-0.20210218204101-be95b93a2d91+incompatible/go.mod h1:pGJSm9DYANtp59DADJgNzFh1uIpkn5xaH3ZBdv1VNTI=
 github.com/peaceiris/hugo-mod-bulma v0.2.0 h1:0Pyx3zT9+1nzYY5eT5JMmL+XGnhL1OFx7LTsSZbKOss=
 github.com/peaceiris/hugo-mod-bulma v0.2.0/go.mod h1:sjw6OFwTiXqh6S26Wk6GYjlSlwgKjYZ06+Bj29FLIqQ=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1 h1:HYfqwE/5dOChaRWBiy8KkNTC6d/RRVNuroE6ld5vGws=
 github.com/peaceiris/hugo-mod-mathjax v0.1.1/go.mod h1:NTn10syjBq7EVnZACmoOlZlg+D3MXLDo9jOLdq5Bm5g=
-github.com/peaceiris/hugo-mod-mermaidjs v0.5.0 h1:ucDrPJVZ+5nwx3YpYduPL3HB2phMkuMrW5t1KOjQ+XU=
-github.com/peaceiris/hugo-mod-mermaidjs v0.5.0/go.mod h1:OmVUZM92FWgDVTt4uZ2qawHGNRRsSMU6uexWMDKjp4o=
+github.com/peaceiris/hugo-mod-mermaidjs v0.6.0 h1:rhW43DXgcHuDsUTvxdBx9QV8pBp5LbWHDgefSy3LTXk=
+github.com/peaceiris/hugo-mod-mermaidjs v0.6.0/go.mod h1:Evqp1vX8GAhk5UDjAe1/VXmXn3ej34HdKFabu+rMVk4=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0 h1:uIdNBMhSiRujqaf7WHqcXb2qsmkodFVL1o2Vzm/aS6Q=
 github.com/peaceiris/hugo-mod-revealjs v0.2.0/go.mod h1:j0j0jS675O/rIk2kBdyTbkQebg9wYSriFfDZG+SkHYs=


### PR DESCRIPTION
- [Release hugo-mod-mermaidjs v0.6.0 · peaceiris/hugo-mod-mermaidjs](https://github.com/peaceiris/hugo-mod-mermaidjs/releases/tag/v0.6.0)
- [Release 8.9.1 · mermaid-js/mermaid](https://github.com/mermaid-js/mermaid/releases/tag/8.9.1)