### PR TITLE
Fix template for google analytics

### DIFF
--- a/layouts/partials/head/general.html
+++ b/layouts/partials/head/general.html
@@ -2,7 +2,7 @@
 
 <!-- Google Analytics -->
 {{ if hugo.IsProduction }}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 
 <!-- cf. https://github.com/joshbuchea/HEAD -->


### PR DESCRIPTION
When previewing the example site with latest hugo version 0.130.0, an error is thrown:

```
ERROR render of "section" failed: "/home/andreas/hugo-theme-iris/layouts/_default/baseof.html:3:5": execute of template failed: template: _default/list.html:3:5: executing "_default/list.html" at <partial "head" .>: error calling partial: "/home/andreas/hugo-theme-iris/layouts/partials/head.html:2:5": execute of template failed: template: partials/head.html:2:5: executing "partials/head.html" at <partial "head/general" .>: error calling partial: execute of template failed: html/template:partials/head/general.html:5:14: no such template "_internal/google_analytics_async.html"
```

This PR fixes this issue.