### PR TITLE
Update Hugo and add diff shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,18 @@ Please follow the instruction as the same as the `repo` shortcode.
 |---|---|
 | ![Shortcode table mouse out](https://raw.githubusercontent.com/peaceiris/hugo-theme-iris/main/exampleSite/assets/images/shortcode_table_1.jpg) | ![Shortcode table mouse over](https://raw.githubusercontent.com/peaceiris/hugo-theme-iris/main/exampleSite/assets/images/shortcode_table_2.jpg) |
 
+### diff
+
+Render a highlighted unified diff with Hugo's `strings.Diff` function.
+
+```md
+{{< diff oldName="before.html" newName="after.html" >}}
+<p>Powered by Hugo v0.124.1</p>
+---
+<p>Powered by Hugo v0.125.7</p>
+{{< /diff >}}
+```
+
 ### math
 
 See also [the example page](https://hugothemeiris.peaceiris.com/posts/math/).

--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.18
 
-require github.com/gohugoio/hugo v0.124.1
+require github.com/gohugoio/hugo v0.125.7
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -170,6 +170,8 @@ github.com/gohugoio/hugo v0.124.0 h1:qt58dsFTFtDHofAcDBc3ej1RVLPDakdTIkUekSj5VwQ
 github.com/gohugoio/hugo v0.124.0/go.mod h1:CPCoslX98OhB9fPukLYbwNzRasEcVclZ2ZSj6eDSEGo=
 github.com/gohugoio/hugo v0.124.1 h1:1kJRnoDCYqSMF8Mm5Pvi4pD/y158N4y+LulFIwtC7ho=
 github.com/gohugoio/hugo v0.124.1/go.mod h1:CPCoslX98OhB9fPukLYbwNzRasEcVclZ2ZSj6eDSEGo=
+github.com/gohugoio/hugo v0.125.7 h1:2V0jHo/FNigM3WtqTJZN7k4RAEE9EK0PJzsF9FU/y5w=
+github.com/gohugoio/hugo v0.125.7/go.mod h1:SsHQwk6Ma4OlGuBF3UmVfTPyWKiZMwBmMZSEdyV4hw0=
 github.com/gohugoio/locales v0.14.0 h1:Q0gpsZwfv7ATHMbcTNepFd59H7GoykzWJIxi113XGDc=
 github.com/gohugoio/locales v0.14.0/go.mod h1:ip8cCAv/cnmVLzzXtiTpPwgJ4xhKZranqNqtoIu0b/4=
 github.com/gohugoio/localescompressed v1.0.1 h1:KTYMi8fCWYLswFyJAeOtuk/EkXR/KPTHHNN9OS+RTxo=

--- a/exampleSite/content/en/posts/markdown-syntax.md
+++ b/exampleSite/content/en/posts/markdown-syntax.md
@@ -140,6 +140,18 @@ Tables aren't part of the core Markdown spec, but Hugo supports supports them ou
 </html>
 {{< /highlight >}}
 
+### Code diff with the diff shortcode
+
+{{< diff oldName="before.html" newName="after.html" >}}
+<div class="message">
+  <p>Powered by Hugo v0.124.1</p>
+</div>
+---
+<div class="message">
+  <p>Powered by Hugo v0.125.7</p>
+</div>
+{{< /diff >}}
+
 
 
 ## List Types

--- a/layouts/partials/head/general.html
+++ b/layouts/partials/head/general.html
@@ -2,7 +2,7 @@
 
 <!-- Google Analytics -->
 {{ if hugo.IsProduction }}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 
 <!-- cf. https://github.com/joshbuchea/HEAD -->

--- a/layouts/shortcodes/diff.html
+++ b/layouts/shortcodes/diff.html
@@ -1,0 +1,21 @@
+{{ $oldName := or (.Get "oldName") "old" }}
+{{ $newName := or (.Get "newName") "new" }}
+{{ $separator := or (.Get "separator") "\n---\n" }}
+{{ $inner := replace .Inner "\r\n" "\n" }}
+{{ $parts := split (trim $inner "\n") $separator }}
+
+{{ if ne (len $parts) 2 }}
+  {{ errorf "The %q shortcode requires exactly two text blocks separated by %q. See %s" .Name (trim $separator "\n") .Position }}
+{{ else }}
+  {{ $old := trim (index $parts 0) "\n" }}
+  {{ $new := trim (index $parts 1) "\n" }}
+  {{ $diff := strings.Diff $oldName $old $newName $new }}
+
+  {{ if $diff }}
+    <div class="code-block diff-block">
+      {{ transform.Highlight $diff "diff" "" }}
+    </div>
+  {{ else }}
+    <p class="diff-block-empty has-text-grey-light is-italic">No differences.</p>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary
- Update the pinned Hugo module from v0.124.1 to v0.125.7.
- Switch the Google Analytics internal template call to the template name available in Hugo v0.125.7.
- Add a `diff` shortcode powered by Hugo v0.125.0's `strings.Diff` template function, with README and example site usage.

## References
- https://github.com/gohugoio/hugo/releases/tag/v0.125.0

## Test plan
- [x] make docker-build
