### PR TITLE
ci: fix setup job theme ref alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir ~/homepage
           cp scripts/setup.sh ~
           cd ~
-          bash ./setup.sh "homepage" "peaceiris"
+          bash ./setup.sh "homepage" "peaceiris" "${GITHUB_SHA}"
           cd homepage
           npm ci
           hugo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,15 +3,25 @@
 # fail on unset variables and command errors
 set -eu -o pipefail # -x: is for debugging
 
-cd $1
+project_name="$1"
+github_id="$2"
+theme_ref="${3:-main}"
+
+cd "${project_name}"
 git init
-wget https://github.com/peaceiris/hugo-theme-iris/archive/main.zip
-unzip main.zip
-rm main.zip
-hugo mod init "github.com/$2/$1"
-cp -r ./hugo-theme-iris-main/exampleSite/{.gitignore,assets,config,content,data,i18n,package-lock.json,package.json,scripts,static} .
+theme_archive="hugo-theme-iris.zip"
+wget -O "${theme_archive}" "https://github.com/peaceiris/hugo-theme-iris/archive/${theme_ref}.zip"
+unzip "${theme_archive}"
+rm "${theme_archive}"
+theme_dir="$(find . -maxdepth 1 -type d -name 'hugo-theme-iris-*' -print | head -n 1)"
+if [[ -z "${theme_dir}" ]]; then
+  echo "failed to extract hugo-theme-iris archive for ${theme_ref}" >&2
+  exit 1
+fi
+hugo mod init "github.com/${github_id}/${project_name}"
+cp -r "${theme_dir}"/exampleSite/{.gitignore,assets,config,content,data,i18n,package-lock.json,package.json,scripts,static} .
 rm ./assets/images/.gitignore
-rm -rf hugo-theme-iris-main
-hugo mod get -u github.com/peaceiris/hugo-theme-iris
+rm -rf "${theme_dir}"
+hugo mod get -u "github.com/peaceiris/hugo-theme-iris@${theme_ref}"
 git add .
 git commit -m "Add hugo-theme-iris"


### PR DESCRIPTION
## Summary
- Add a theme ref argument to `scripts/setup.sh` so the archive download and Hugo module dependency use the same ref.
- Pass `${GITHUB_SHA}` from the `setup` job so the generated example site uses the theme code from the commit being tested.
- Fail explicitly when the extracted archive directory cannot be found.

## Notes
- Since `4aeaba4a09dc98cb8e047a46660ea1874780c51e`, the example content on `main` references the new `diff` shortcode, while `hugo mod get -u github.com/peaceiris/hugo-theme-iris` resolved the latest release tag, which did not include that shortcode yet. This caused `template for shortcode "diff" not found`.
- The script accepts a ref instead of hardcoding `main`, so the setup check can still validate PR commits if the job is enabled for pull requests later.

## Test plan
- [x] `bash -n scripts/setup.sh`
- [x] `git diff --check main...HEAD`
- [ ] Full setup / `npm ci` / `hugo` was not run locally because the sandbox cannot resolve the npm registry DNS.
