### PR TITLE
Clarify repository-facing language requirements in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@ Recent history uses Conventional Commits, for example `build: bump hugo from v0.
 ## Agent-Specific Instructions
 
 When acting as an automated contributor in this repository, communicate with the user in Japanese unless they request another language.
+Use English for repository-facing content, including documentation, code comments, commit messages, and pull request text, unless the task explicitly requires another language.


### PR DESCRIPTION
**Summary**
- Add a repository-specific instruction to write documentation, code comments, commit messages, and PR text in English.
- Keep user-facing conversation in Japanese unless another language is requested.

**Testing**
- Not run (not requested)

**Ref**
- Updated [AGENTS.md](/Users/s15459/.codex/worktrees/9136/hugo-theme-iris/AGENTS.md) with the new language guidance.