### PR TITLE
Bump Hugo to v0.127.0

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.18
 
-require github.com/gohugoio/hugo v0.126.2
+require github.com/gohugoio/hugo v0.127.0
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -55,8 +55,9 @@ github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e h1:QArsSubW7eDh8APMXkByjQWvuljwPGAGQpJEFn0F0wY=
-github.com/gohugoio/hugo v0.126.2 h1:ZtC/eDL4jx+ZaJ0RjyKjI0DAQebc7HWp2gw82pVIPzc=
-github.com/gohugoio/hugo v0.126.2/go.mod h1:wo66RnKrp9Mx0WeeF22LJxPY6YB+v2weKdZpHa8fI/A=
+github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
+github.com/gohugoio/hugo v0.127.0 h1:7iKOa0NntxekHHkx2sc4BTsNUpTYE28jnpNM3vrvNr4=
+github.com/gohugoio/hugo v0.127.0/go.mod h1:CH5I652/zeb3xwK7dOpd4GFn6ID2hOyvBXaJ2uNDRYQ=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.1.0 h1:YhxZNU8y2vxV6Ibr7QJzzUlpr8oHHWX/l+Q1R/a5Zao=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.2.0 h1:PCtO5l++psZf48yen2LxQ3JiOXxaRC6v0594NeHvGZg=
 github.com/gohugoio/locales v0.14.0 h1:Q0gpsZwfv7ATHMbcTNepFd59H7GoykzWJIxi113XGDc=


### PR DESCRIPTION
## 概要

- Bump the pinned Hugo dependency in `deps/go.mod` from v0.126.2 to v0.127.0.
- Refresh `deps/go.sum`, including the new `github.com/gohugoio/httpcache v0.7.0` checksum introduced by Hugo v0.127.0.

## 参考

- Hugo v0.126.3: https://github.com/gohugoio/hugo/releases/tag/v0.126.3
- Hugo v0.127.0: https://github.com/gohugoio/hugo/releases/tag/v0.127.0
- `theme.toml` `min_version` remains `0.126.0`; this bump does not make the theme or example site rely on v0.127-only behavior.
- No remote-resource HTTP cache example was added because this theme currently does not use `resources.GetRemote`, and builds should remain local/static.

## Test plan

- [x] `make npm-ci`
- [x] `PATH=/private/tmp/hugo-v0.127.0:$PATH npm test`
- [x] `PATH=/private/tmp/hugo-v0.127.0:$PATH make build-staging`
- [x] `make docker-build`
