### PR TITLE
Bump Hugo to v0.130.0

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.18
 
-require github.com/gohugoio/hugo v0.129.0
+require github.com/gohugoio/hugo v0.130.0
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -16,6 +16,7 @@ github.com/bep/godartsass/v2 v2.0.0/go.mod h1:AcP8QgC+OwOXEq6im0WgDRYK7scDsmZCEW
 github.com/bep/golibsass v1.1.1 h1:xkaet75ygImMYjM+FnHIT3xJn7H0xBA9UxSOJjk8Khw=
 github.com/bep/golibsass v1.1.1/go.mod h1:DL87K8Un/+pWUS75ggYv41bliGiolxzDKWJAq3eJ1MA=
 github.com/bep/gowebp v0.3.0 h1:MhmMrcf88pUY7/PsEhMgEP0T6fDUnRTMpN8OclDrbrY=
+github.com/bep/imagemeta v0.7.4 h1:8lBFK/mJmVuAmToy+lk59DbtotRLadDlXxZobJztCww=
 github.com/bep/lazycache v0.4.0 h1:X8yVyWNVupPd4e1jV7efi3zb7ZV/qcjKQgIQ5aPbkYI=
 github.com/bep/logg v0.4.0 h1:luAo5mO4ZkhA5M1iDVDqDqnBBnlHjmtZF6VAyTp+nCQ=
 github.com/bep/logg v0.4.0/go.mod h1:Ccp9yP3wbR1mm++Kpxet91hAZBEQgmWgFgnXX3GkIV0=
@@ -58,8 +59,8 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gohugoio/go-i18n/v2 v2.1.3-0.20230805085216-e63c13218d0e h1:QArsSubW7eDh8APMXkByjQWvuljwPGAGQpJEFn0F0wY=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
-github.com/gohugoio/hugo v0.129.0 h1:AWyne6qC/fg/XNTLHpuaefXHkukzAWBmSkersovh8tI=
-github.com/gohugoio/hugo v0.129.0/go.mod h1:PBbF9ucsywUwysYkwUEYfK5IWH045VVdxKz7KZ7kYyY=
+github.com/gohugoio/hugo v0.130.0 h1:K4abLV4uru6YYLzq48kG5f3jXpTkPbDdBHIeZOixlhg=
+github.com/gohugoio/hugo v0.130.0/go.mod h1:qjUrDU4qAt92TPhOUJg4Noz/jMiGm32lISkuAjh6B8A=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.2.0 h1:PCtO5l++psZf48yen2LxQ3JiOXxaRC6v0594NeHvGZg=
 github.com/gohugoio/locales v0.14.0 h1:Q0gpsZwfv7ATHMbcTNepFd59H7GoykzWJIxi113XGDc=
@@ -128,7 +129,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=


### PR DESCRIPTION
## 概要

- Bump the pinned Hugo dependency in `deps/go.mod` from `v0.129.0` to `v0.130.0` and refresh `deps/go.sum`.
- Keep the v0.130 migration scoped to the `deps/` Go module because the release notes do not require theme, template, or example-site changes.
- Leave `theme.toml` `min_version` at `0.128.0` because the theme and example site do not rely on v0.130-only behavior.

## 参考

- Closes #1944
- Hugo v0.130.0: https://github.com/gohugoio/hugo/releases/tag/v0.130.0
- The release adds template `math` trigonometric/angle helpers, but the existing MathJax page does not use Hugo template math functions.
- The release switches Hugo's EXIF library; existing image render hooks and shortcodes were validated by the rendered example site with 12 processed images.
- Validation still reports the existing Hugo v0.120 deprecation warnings for `.Site.DisqusShortname` and `.Site.IsServer`; no new migration warning was observed.

## Test plan

- [x] `make npm-ci`
- [x] `PATH=/private/tmp/hugo-v0.130.0:$PATH npm test`
- [x] `PATH=/private/tmp/hugo-v0.130.0:$PATH make build-staging`
- [x] `make docker-build`
