### PR TITLE
ci: use official Hugo Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,11 +159,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: peaceiris/workflows/setup-hugo@344651af76054dbb5c8231c3d0a18b109c029630 # v0.20.1
+      - uses: peaceiris/workflows/setup-node@344651af76054dbb5c8231c3d0a18b109c029630 # v0.20.1
         with:
           node-version: "${{ needs.envs.outputs.NODE_VERSION }}"
-          hugo-version: "${{ needs.envs.outputs.HUGO_VERSION }}"
-          extended: true
+          cache: "npm"
 
       - name: prepare
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ git clone https://github.com/<username>/hugo-theme-iris.git
 cd ./hugo-theme-iris
 
 # (3) Start Hugo Server with Docker.
-make up
+make docker-dev
 ```
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ cmd := ""
 DOCKER_COMPOSE := docker compose
 GH_USER_ID := peaceiris
 HUGO_GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir)
+CI_OWNER ?= 1000:1000
 
 
 .PHONY: bump-node
@@ -38,7 +39,7 @@ docker-test: npm-ci docker-prepare
 .PHONY: docker-prepare
 docker-prepare:
 	@if [ "$${CI:-}" = "true" ]; then \
-		sudo chown -R 1000:1000 ./exampleSite; \
+		sudo chown -R $(CI_OWNER) ./exampleSite; \
 	fi
 
 .PHONY: npm-ci

--- a/Makefile
+++ b/Makefile
@@ -10,30 +10,36 @@ bump-node:
 	bash scripts/bump_node.sh
 
 .PHONY: docker-dev
-docker-dev: npm-ci
+docker-dev: npm-ci docker-prepare
 	$(eval opt := server --navigateToChanged --bind=0.0.0.0 --buildDrafts)
 	export HUGO_VERSION=v$(shell make get-hugo-version) HUGO_GIT_COMMON_DIR="$(HUGO_GIT_COMMON_DIR)" && \
 	$(DOCKER_COMPOSE) up -d && \
 	$(DOCKER_COMPOSE) exec hugo hugo $(opt)
 
 .PHONY: docker-hugo
-docker-hugo: npm-ci
+docker-hugo: npm-ci docker-prepare
 	# make docker-hugo cmd="version"
 	export HUGO_VERSION=v$(shell make get-hugo-version) HUGO_GIT_COMMON_DIR="$(HUGO_GIT_COMMON_DIR)" && \
 	$(DOCKER_COMPOSE) run --rm --entrypoint=hugo hugo $(cmd)
 
 .PHONY: docker-build
-docker-build: npm-ci
+docker-build: npm-ci docker-prepare
 	$(eval opt := --minify --cleanDestinationDir)
 	export HUGO_VERSION=v$(shell make get-hugo-version) HUGO_GIT_COMMON_DIR="$(HUGO_GIT_COMMON_DIR)" && \
 	$(DOCKER_COMPOSE) run --rm --entrypoint=hugo hugo $(opt)
 
 .PHONY: docker-test
-docker-test: npm-ci
+docker-test: npm-ci docker-prepare
 	$(eval opt := --minify --renderToMemory --printPathWarnings --logLevel debug \
 		--templateMetrics --templateMetricsHints)
 	export HUGO_VERSION=v$(shell make get-hugo-version) HUGO_GIT_COMMON_DIR="$(HUGO_GIT_COMMON_DIR)" && \
 	$(DOCKER_COMPOSE) run --rm --entrypoint=hugo hugo $(opt)
+
+.PHONY: docker-prepare
+docker-prepare:
+	@if [ "$${CI:-}" = "true" ]; then \
+		sudo chown -R 1000:1000 ./exampleSite; \
+	fi
 
 .PHONY: npm-ci
 npm-ci:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,22 @@
-version: "3"
-
 services:
   hugo:
     container_name: hugo_theme_iris
-    image: ghcr.io/peaceiris/hugo:${HUGO_VERSION}-mod
+    image: ghcr.io/gohugoio/hugo:${HUGO_VERSION}
     ports:
       - 1313:1313
     volumes:
-      - ${PWD}:/src/hugo-theme-iris
-      - ${HUGO_GIT_COMMON_DIR:-.git}:${HUGO_GIT_COMMON_DIR:-/src/hugo-theme-iris/.git}:ro
-      - ${HUGO_CACHEDIR}:/root/.cache/hugo
+      - ${PWD}:/project
+      - ${HUGO_GIT_COMMON_DIR:-.git}:${HUGO_GIT_COMMON_DIR:-/project/.git}:ro
+      - hugo-cache:/cache
     environment:
-      - HUGO_CACHEDIR=/root/.cache/hugo
+      - HUGO_CACHEDIR=/cache
     stdin_open: true
     tty: true
-    working_dir: /src/hugo-theme-iris/exampleSite
-    entrypoint: bash
+    working_dir: /project/exampleSite
+    entrypoint: sh
+    command:
+      - -c
+      - tail -f /dev/null
+
+volumes:
+  hugo-cache:


### PR DESCRIPTION
## 概要
- Migrate local Docker Compose targets from `ghcr.io/peaceiris/hugo:* -mod` to the official `ghcr.io/gohugoio/hugo:${HUGO_VERSION}` image.
- Align Docker paths, cache handling, and parameterized CI-only permissions with the official image's non-root `hugo` user.
- Keep the regular CI `deploy` and `setup` jobs on `peaceiris/workflows/setup-hugo`; only the Docker validation job uses the Docker path.

## 参考
- Closes #1957
- Official Hugo tagged images are available from Hugo v0.135.0, and this repository currently pins Hugo v0.136.5.
- Review focus: local `make docker-*` behavior and the `docker` CI job permission adjustment.

## Test plan
- [x] `make get-hugo-version`
- [x] `make docker-hugo cmd="version"`
- [x] `make docker-test`
- [x] `make docker-build`
- [x] `docker compose config`
- [x] `docker compose up -d`; `docker compose exec hugo hugo version`; `docker compose down`
- [x] `CI=true make -n docker-prepare`
- [x] `CI=true make -n docker-prepare CI_OWNER=1234:5678`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build workflow with improved caching for dependency installation
  * Streamlined Docker container configuration for local development
  * Updated Docker image sourcing and volume management

* **Documentation**
  * Updated development setup instructions to reflect new Docker commands

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/1961)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
