### PR TITLE
build: bump Hugo to v0.138.0

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.22
 
-require github.com/gohugoio/hugo v0.137.1
+require github.com/gohugoio/hugo v0.138.0
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -81,8 +81,8 @@ github.com/gohugoio/hashstructure v0.1.0 h1:kBSTMLMyTXbrJVAxaKI+wv30MMJJxn9Q8kfQ
 github.com/gohugoio/hashstructure v0.1.0/go.mod h1:8ohPTAfQLTs2WdzB6k9etmQYclDUeNsIHGPAFejbsEA=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo v0.137.1 h1:40oIAWoJjpjhlOLVHwFtWJWkcIRbB7vtUMEeg4mVEGQ=
-github.com/gohugoio/hugo v0.137.1/go.mod h1:xWGhklCQSsRpPSN4+2mDf13V7y9AnoC34fniCGyxsn0=
+github.com/gohugoio/hugo v0.138.0 h1:XcojmHOKEKYSTubX+mHT+ZtLlL6jaxjBFf4Fs5GxqZY=
+github.com/gohugoio/hugo v0.138.0/go.mod h1:xWGhklCQSsRpPSN4+2mDf13V7y9AnoC34fniCGyxsn0=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0/go.mod h1:oBdBVuiZ0fv9xd8xflUgt53QxW5jOCb1S+xntcN4SKo=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.0 h1:7PY5PIJ2mck7v6R52yCFvvYHvsPMEbulgRviw3I9lP4=


### PR DESCRIPTION
## Summary

- Bump the pinned Hugo dependency in `deps/go.mod` from `v0.137.1` to `v0.138.0` and refresh `deps/go.sum`.
- Keep the `deps/go.mod` Go directive in the CI-compatible `go 1.22` form after `go get`/`go mod tidy` rewrote it to `go 1.22.6`.
- Leave `theme.toml` `min_version` unchanged because this migration does not introduce theme or example-site behavior that relies on v0.138-only features.

## References

- Closes #1967
- Hugo v0.138.0: https://github.com/gohugoio/hugo/releases/tag/v0.138.0
- `Page.Scratch` docs: https://gohugo.io/methods/page/scratch/
- `Page.Store` docs: https://gohugo.io/methods/page/store/
- The release notes mention `Page.Scratch` being aliased to `Page.Store` and a short page lookup concurrency fix; this theme currently has no `.Scratch`/`.Store` template or example-site usage, so no example coverage was added.
- `npm ci` still reports the existing 4 audit vulnerabilities during Docker validation.

## Test plan

- [x] `make get-hugo-version`
- [x] `git diff --check`
- [x] `make docker-build`
- [ ] `make dev` visual inspection (not run; this change is dependency-only and `make docker-build` rendered the example site successfully with Hugo v0.138.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core build technology to the latest stable version for improved performance and stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/1968)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->