### PR TITLE
ci: migrate labeler config for v6

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,20 @@
 cicd:
-  - .github/workflows/*
-  - renovate.json
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/*"
+          - "renovate.json"
 
 dependencies:
-  - .nvmrc
-  - package.json
-  - package-lock.json
-  - go.mod
-  - go.sum
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".nvmrc"
+          - "package.json"
+          - "package-lock.json"
+          - "go.mod"
+          - "go.sum"
 
 documentation:
-  - README.md
-  - CONTRIBUTING.md
+  - changed-files:
+      - any-glob-to-any-file:
+          - "README.md"
+          - "CONTRIBUTING.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     permissions:
+      contents: read
       pull-requests: write
     steps:
       # https://github.com/actions/labeler


### PR DESCRIPTION
## Summary
- Migrates `.github/labeler.yml` from the legacy label-to-globs syntax to the `changed-files` matcher format used by actions/labeler v6.
- Adds explicit `contents: read` permission for the labeler workflow while keeping `pull-requests: write`.

## References
- Follow-up to #1973.
- The `Pull Request Labeler / triage` check can fail on this PR until the config is merged because `pull_request_target` executes from the base branch and currently reads the pre-migration labeler config.
- actions/labeler v6.1.0 configuration and `pull_request_target` migration notes: https://github.com/actions/labeler

## Test plan
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); YAML.load_file(".github/workflows/labeler.yml"); puts "YAML OK"'`
- [x] `git diff --check HEAD~1..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request labeling configuration with improved file-change detection for categorizing CI/CD, dependencies, and documentation modifications.
  * Enhanced CI/CD workflow permissions to support improved pull request triage automation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/1981)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->