### PR TITLE
build: bump Hugo to v0.142.0

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.22
 
-require github.com/gohugoio/hugo v0.141.0
+require github.com/gohugoio/hugo v0.142.0
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -70,8 +70,8 @@ github.com/gohugoio/hashstructure v0.3.0 h1:orHavfqnBv0ffQmobOp41Y9HKEMcjrR/8EFA
 github.com/gohugoio/hashstructure v0.3.0/go.mod h1:8ohPTAfQLTs2WdzB6k9etmQYclDUeNsIHGPAFejbsEA=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo v0.141.0 h1:oTrHI/HTDXFoK4Nmx73xOa1qbx2YUaN0LG+8IV5QNF8=
-github.com/gohugoio/hugo v0.141.0/go.mod h1:G0uwM5aRUXN4cbnqrDQx9Dlgmf/ukUpPADajL8FbL9M=
+github.com/gohugoio/hugo v0.142.0 h1:gOVP52kHxr5dByyKgo/74s35tLIcHiHVwojQ4fmd3A4=
+github.com/gohugoio/hugo v0.142.0/go.mod h1:G0uwM5aRUXN4cbnqrDQx9Dlgmf/ukUpPADajL8FbL9M=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0/go.mod h1:oBdBVuiZ0fv9xd8xflUgt53QxW5jOCb1S+xntcN4SKo=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.0 h1:7PY5PIJ2mck7v6R52yCFvvYHvsPMEbulgRviw3I9lP4=


### PR DESCRIPTION
## Overview

- Bump the pinned Hugo dependency in `deps/go.mod` from `v0.141.0` to `v0.142.0` and refresh the corresponding `deps/go.sum` checksums.
- Keep the `deps/go.mod` Go directive in the CI-compatible `go 1.22` form after `go get` rewrote it to `go 1.22.6`.
- Leave `theme.toml` `min_version` at `0.141.0` because this migration does not introduce theme or example-site behavior that relies on `v0.142.0`-only features.

## References

- Closes #1988
- Hugo `v0.142.0` release notes: https://github.com/gohugoio/hugo/releases/tag/v0.142.0
- The release notes mention generated image hash/cache key changes, a render hook `PlainText` fix, HTML comment warning changes, shortcode error context fixes, and a QR shortcode `loading` attribute. This theme does not use render hook `.PlainText` or the built-in QR shortcode, and existing local image examples already exercise the affected image-processing path, so no scoped example-site changes were added.

## Verification

- [x] `make get-hugo-version`
- [x] `git diff --check`
- [x] `make docker-build`
- [x] `npm test` (passed with the local Homebrew Hugo `v0.161.1`; it reports deprecation warnings for future Hugo versions outside this `v0.142.0` migration)

## Screenshots

N/A. This is a dependency-only update; `make docker-build` rendered the example site with Hugo `v0.142.0+extended` and processed 12 images.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed.
- [x] Visible theme changes were checked locally. (N/A; this PR has no visible theme changes.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hugo dependency to version 0.142.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/1989)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->