### PR TITLE
build: bump Hugo to v0.143.1

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.22
 
-require github.com/gohugoio/hugo v0.142.0
+require github.com/gohugoio/hugo v0.143.1
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -70,8 +70,8 @@ github.com/gohugoio/hashstructure v0.3.0 h1:orHavfqnBv0ffQmobOp41Y9HKEMcjrR/8EFA
 github.com/gohugoio/hashstructure v0.3.0/go.mod h1:8ohPTAfQLTs2WdzB6k9etmQYclDUeNsIHGPAFejbsEA=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo v0.142.0 h1:gOVP52kHxr5dByyKgo/74s35tLIcHiHVwojQ4fmd3A4=
-github.com/gohugoio/hugo v0.142.0/go.mod h1:G0uwM5aRUXN4cbnqrDQx9Dlgmf/ukUpPADajL8FbL9M=
+github.com/gohugoio/hugo v0.143.1 h1:ingkoWPWp2bguLOth0l6z6rpqCnAZ0tODl1PuxATeA4=
+github.com/gohugoio/hugo v0.143.1/go.mod h1:G0uwM5aRUXN4cbnqrDQx9Dlgmf/ukUpPADajL8FbL9M=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0 h1:MNdY6hYCTQEekY0oAfsxWZU1CDt6iH+tMLgyMJQh/sg=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.2.0/go.mod h1:oBdBVuiZ0fv9xd8xflUgt53QxW5jOCb1S+xntcN4SKo=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.0 h1:7PY5PIJ2mck7v6R52yCFvvYHvsPMEbulgRviw3I9lP4=


### PR DESCRIPTION
## Overview

- Bump the pinned Hugo dependency in `deps/go.mod` from `v0.142.0` to `v0.143.1` and refresh the corresponding `deps/go.sum` checksums.
- Keep the `deps/go.mod` Go directive in the CI-compatible `go 1.22` form after `go get` rewrote it to `go 1.22.6`.
- Leave `theme.toml` `min_version` at `0.141.0` because this migration does not introduce theme or example-site behavior that relies on `v0.143.1`-only features.

## References

- Closes #1990
- Hugo `v0.143.0` release notes: https://github.com/gohugoio/hugo/releases/tag/v0.143.0
- Hugo `v0.143.1` release notes: https://github.com/gohugoio/hugo/releases/tag/v0.143.1
- The release notes mention server rebuild fixes, cascade ordering, blockquote render hook text trimming, RSS output with subdirectory `baseURL` when render hooks are enabled, `resources.GetRemote` `responseHeaders`, and built-in `gist` / `comment` shortcode deprecations. This repository has custom Markdown render hooks and RSS links, but no `resources.GetRemote`, built-in `gist`, or built-in `comment` shortcode usage, so no scoped example-site changes were added.

## Verification

- [x] `make get-hugo-version`
- [x] `git diff --check`
- [x] `make docker-build`
- [x] `npm test` (passed with the local Homebrew Hugo `v0.161.1`; it reports deprecation warnings for future Hugo versions outside this `v0.143.1` migration)

## Screenshots

N/A. This is a dependency-only update; `make docker-build` rendered the example site with Hugo `v0.143.1+extended` and processed 12 images.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed. (N/A; no new user-facing Hugo behavior is adopted.)
- [x] Visible theme changes were checked locally. (N/A; this PR has no visible theme changes.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hugo dependency from version 0.142.0 to 0.143.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/1991)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->