### PR TITLE
build: bump Hugo to v0.150.1

### DIFF
--- a/deps/go.mod
+++ b/deps/go.mod
@@ -2,7 +2,7 @@ module theme
 
 go 1.24
 
-require github.com/gohugoio/hugo v0.149.1
+require github.com/gohugoio/hugo v0.150.1
 
 require (
 	github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c // indirect

--- a/deps/go.sum
+++ b/deps/go.sum
@@ -72,8 +72,8 @@ github.com/gohugoio/hashstructure v0.5.0 h1:G2fjSBU36RdwEJBWJ+919ERvOVqAg9tfcYp4
 github.com/gohugoio/hashstructure v0.5.0/go.mod h1:Ser0TniXuu/eauYmrwM4o64EBvySxNzITEOLlm4igec=
 github.com/gohugoio/httpcache v0.7.0 h1:ukPnn04Rgvx48JIinZvZetBfHaWE7I01JR2Q2RrQ3Vs=
 github.com/gohugoio/httpcache v0.7.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo v0.149.1 h1:uWOc8Ve4h4e48FyYhBquRoHCJviyxA5yGrFJLT48yio=
-github.com/gohugoio/hugo v0.149.1/go.mod h1:HS6BP6e8FGxungP4CHC3zeLDvhBLnTJIjHJZWTZjs7o=
+github.com/gohugoio/hugo v0.150.1 h1:9AHz8SSunE9YdUQFNrqEwQGusuJ7R8iiLFvRtEoTp5I=
+github.com/gohugoio/hugo v0.150.1/go.mod h1:+c6VffXGahbNCe/wTQ05FkKMjT/fZqN6Gq3tgBfUhNw=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.5.0 h1:dco+7YiOryRoPOMXwwaf+kktZSCtlFtreNdiJbETvYE=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.5.0/go.mod h1:CRrxQTKeM3imw+UoS4EHKyrqB7Zp6sAJiqHit+aMGTE=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.1 h1:nUzXfRTszLliZuN0JTKeunXTRaiFX6ksaWP0puLLYAY=
@@ -179,8 +179,8 @@ golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b/go.mod h1:4QTo5u+SEIbbKW1Rac
 golang.org/x/image v0.30.0 h1:jD5RhkmVAnjqaCUXfbGBrn3lpxbknfN9w2UhHHU+5B4=
 golang.org/x/image v0.30.0/go.mod h1:SAEUTxCCMWSrJcCy/4HwavEsfZZJlYxeHLc6tTiAe/c=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
-golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
+golang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=
+golang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=


### PR DESCRIPTION
## Overview

- Bump the pinned Hugo dependency in `deps/go.mod` from `v0.149.1` to `v0.150.1` and refresh the corresponding `deps/go.sum` checksums.
- Keep the `deps/go.mod` Go directive in the CI-compatible major.minor form `go 1.24` after `go get` temporarily rewrote it to `go 1.24.0`.
- Keep `theme.toml` `min_version` unchanged because the theme and example site do not rely on Hugo `v0.150.x`-only behavior.

## References

- Closes #2006
- Hugo `v0.150.0` release notes: https://github.com/gohugoio/hugo/releases/tag/v0.150.0
- Hugo `v0.150.1` release notes: https://github.com/gohugoio/hugo/releases/tag/v0.150.1
- The release notes mention module import `version` configuration, truncated summary logic, duplicate content path warning log-level changes, and `--minify` flag mapping. This theme does not need new `v0.150.x`-specific example coverage; the existing example site already exercises module imports, custom render hooks, generated summaries, generated ToC output, custom shortcodes, code blocks, local image handling, aliases, RSS output, and multilingual pages.
- `npm ci` still reports the existing 1 moderate audit vulnerability during Docker validation.

## Verification

- [x] `make get-hugo-version`
- [x] `make get-go-version`
- [x] `git diff --check`
- [x] `make docker-build`
- [x] `make docker-test`
- [x] `npm test` (passed with local Homebrew Hugo `v0.161.1`; it reports existing future-version deprecation warnings outside this `v0.150.1` migration.)

## Screenshots

N/A. This change updates the Hugo dependency pin and checksum files only; `make docker-build` rendered the example site successfully with Hugo `v0.150.1+extended+withdeploy` and processed 12 images. `make docker-test` also exercised custom Markdown render hooks, generated ToC output, shortcode output, RSS table render hooks, local image handling, aliases, and multilingual pages without path warnings or minifier warnings.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed.
- [x] Visible theme changes were checked locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hugo dependency to the latest version, bringing performance improvements and stability enhancements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/2007)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->