### PR TITLE
fix: enable Goldmark passthrough for math

### DIFF
--- a/exampleSite/config/_default/config.yaml
+++ b/exampleSite/config/_default/config.yaml
@@ -58,6 +58,19 @@ markup:
           enable: true
         superscript:
           enable: true
+      passthrough:
+        delimiters:
+          block:
+            - - '\['
+              - '\]'
+            - - $$
+              - $$
+          inline:
+            - - '\('
+              - '\)'
+            - - $
+              - $
+        enable: true
       strikethrough: false
     renderer:
       unsafe: true


### PR DESCRIPTION
## Overview

- Enable Goldmark passthrough delimiters for MathJax block and inline math in the example site config.
- Preserve raw LaTeX before Markdown extras such as superscript run, fixing `/posts/math/` rendering for `$$...$$`.

## References

- Hugo passthrough render hooks: https://gohugo.io/render-hooks/passthrough/
- Fixes the local `/posts/math/` MathJax rendering issue.

## Verification

- [x] `make test`
- [x] `hugo --destination /private/tmp/hugo-theme-iris-public --cleanDestinationDir --printPathWarnings`
- [x] Checked `http://localhost:1313/posts/math/` in the in-app browser: MathJax rendered 5 `mjx-container` elements and no raw `<sup>` conversion remained.

## Screenshots

N/A. Visual behavior was checked locally on `/posts/math/`.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed.
- [x] Visible theme changes were checked locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled passthrough rendering with explicit delimiters for block and inline content, allowing users to render mathematical expressions and other formatted content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/2032)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->