### PR TITLE
Update GitHub Actions runner labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   renovate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     timeout-minutes: 3
     permissions: {}
     steps:
@@ -35,7 +35,7 @@ jobs:
       - run: npm run test:renovate
 
   envs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     permissions: {}
     outputs:
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     needs: envs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     permissions:
       contents: write
@@ -112,7 +112,7 @@ jobs:
   lighthouse:
     needs: deploy
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -151,7 +151,7 @@ jobs:
 
   docker:
     needs: envs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     permissions:
@@ -172,7 +172,7 @@ jobs:
 
   setup:
     needs: envs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,13 +5,14 @@ name: 'Dependency Review'
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions: {}
     steps:


### PR DESCRIPTION
## Overview

- Update general GitHub Actions jobs from `ubuntu-22.04` to `ubuntu-24.04`.
- Move lightweight workflow jobs to `ubuntu-slim` and keep dependency-review permissions scoped at the job level.

## References

- N/A

## Verification

- [x] `actionlint`
- [x] Confirmed no `ubuntu-22.04` runner labels remain under `.github/workflows`.
- [ ] `npm test` (not run; workflow-only change with no theme render impact)

## Screenshots

N/A, no visible theme changes.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed. (No documentation or example changes required.)
- [x] Visible theme changes were checked locally. (N/A, no visible theme changes.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner environments across multiple workflows to use newer Ubuntu versions and optimized runner configurations for improved CI/CD efficiency and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/hugo-theme-iris/pull/2044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->