### PR TITLE
Use Hugo ancestors for breadcrumbs

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,23 +1,12 @@
 <nav class="breadcrumb" aria-label="breadcrumbs">
   <ul>
-    {{- template "breadcrumb" (dict "node" . "start" .) -}}
+    {{- range .Ancestors.Reverse -}}
+      <li>
+        <a href="{{- .Permalink -}}">{{- .LinkTitle -}}</a>
+      </li>
+    {{- end -}}
+    <li class="is-active">
+      <a href="#" aria-current="page" class="normal-link">{{- .LinkTitle | truncate 20 -}}</a>
+    </li>
   </ul>
 </nav>
-
-{{- define "breadcrumb" -}}
-  {{- if .node.Parent -}}
-    {{- template "breadcrumb" (dict "node" .node.Parent "start" .start) -}}
-  {{- else if not .node.IsHome -}}
-    {{- template "breadcrumb" (dict "node" .node.Site.Home "start" .start) -}}
-  {{- end -}}
-
-  {{- if eq .node .start -}}
-    <li class="is-active">
-      <a href="#" aria-current="page" class="normal-link">{{- .node.LinkTitle | truncate 20 -}}</a>
-    </li>
-  {{- else -}}
-    <li>
-      <a href="{{- .node.Permalink -}}">{{- .node.LinkTitle -}}</a>
-    </li>
-  {{- end -}}
-{{- end -}}


### PR DESCRIPTION
## Overview

- Simplify the breadcrumb partial with Hugo's `Page.Ancestors.Reverse`.
- Preserve the current Home > section > page breadcrumb output while removing the recursive template helper.

## References

- Closes #600
- Hugo v0.109.0 release notes: https://github.com/gohugoio/hugo/releases/tag/v0.109.0

## Verification

- [x] `make npm-ci`
- [x] `make test`
- [x] `hugo --destination /private/tmp/hugo-theme-iris-public --cleanDestinationDir`
- [x] Checked generated breadcrumb HTML for the home page and a nested post page.

## Screenshots

N/A. The visible breadcrumb output was checked via generated HTML.

## Checklist

- [x] The change is focused and avoids unrelated updates.
- [x] Documentation or examples were updated when needed.
- [x] Visible theme changes were checked locally.
